### PR TITLE
ORM reload fails with a default model connection

### DIFF
--- a/SailsRest.js
+++ b/SailsRest.js
@@ -345,6 +345,20 @@ module.exports = (function() {
       cb();
     },
 
+    teardown: function (connection, cb) {
+      if (typeof connection == 'function') {
+        cb = connection;
+        connection = null;
+      }
+      if (connection == null) {
+        connections = {};
+        return cb();
+      }
+      if(!connections[connection]) return cb();
+      delete connections[connection];
+      cb();
+    },
+
     create: function(connection, collectionName, values, cb) {
       makeRequest(connection, collectionName, 'create', cb, null, values);
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-rest",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "REST adapter for Sails.js",
   "main": "SailsRest.js",
   "scripts": {


### PR DESCRIPTION
and version number up because change api
https://github.com/balderdashy/sails/issues/2332
